### PR TITLE
SSP-2430: Updating external_substitutable_course Column Names To Match SSP's

### DIFF
--- a/ssp-data-importer-impl/src/main/resources/sql/postgres/postgres-2.4.0-create.sql
+++ b/ssp-data-importer-impl/src/main/resources/sql/postgres/postgres-2.4.0-create.sql
@@ -471,11 +471,11 @@ CREATE TABLE stg_external_substitutable_course (
     source_formatted_course character varying(35) NOT NULL,
     source_course_code  character varying(50) ,
     source_course_title character varying(100) ,
-    source_course_hours  numeric(9,2) ,
+    source_credit_hours  numeric(9,2) ,
     target_formatted_course  character varying(35) NOT NULL,
     target_course_code character varying(50),
     target_course_title  character varying(100),
-    target_course_hours  numeric(9,2)
+    target_credit_hours  numeric(9,2)
 );
 
 

--- a/ssp-data-importer-impl/src/main/resources/sql/sqlserver/sqlserver-2.4.0-create.sql
+++ b/ssp-data-importer-impl/src/main/resources/sql/sqlserver/sqlserver-2.4.0-create.sql
@@ -815,11 +815,11 @@ CREATE TABLE stg_external_substitutable_course (
     [source_formatted_course] [nvarchar](35) NOT NULL,
     [source_course_code]  [nvarchar](50),
     [source_course_title][nvarchar](100),
-    [source_course_hours]  [decimal](9,2),
+    [source_credit_hours]  [decimal](9,2),
     [target_formatted_course]  [nvarchar](35) NOT NULL,
     [target_course_code] [nvarchar](50),
     [target_course_title]  [nvarchar](100),
-    [target_course_hours]  [decimal](9,2),
+    [target_credit_hours]  [decimal](9,2),
     PRIMARY KEY CLUSTERED 
 (
     [source_formatted_course] ASC,

--- a/ssp-data-importer-impl/src/test/resources/data-test/ssp-external-tables-input-test/external_substitutable_course.csv
+++ b/ssp-data-importer-impl/src/test/resources/data-test/ssp-external-tables-input-test/external_substitutable_course.csv
@@ -1,2 +1,2 @@
-term_code,program_code,source_formatted_course,source_course_code,source_course_title,source_course_hours,target_formatted_course,target_course_code,target_course_title,target_course_hours
+term_code,program_code,source_formatted_course,source_course_code,source_course_title,source_credit_hours,target_formatted_course,target_course_code,target_course_title,target_credit_hours
 FA2015,HST-AA,HISTORY 101,HST-101,HISTORY THE GREAT TEACHER,3,HISTORY 103,HST-101,HISTORY THE GREATEST TEACHER,3

--- a/ssp-data-importer-impl/src/test/resources/sql/postgres/postgres-2.4.0-test-tables-create.sql
+++ b/ssp-data-importer-impl/src/test/resources/sql/postgres/postgres-2.4.0-test-tables-create.sql
@@ -376,11 +376,11 @@ CREATE TABLE stg_external_substitutable_course (
     source_formatted_course character varying(35) NOT NULL,
     source_course_code  character varying(50) ,
     source_course_title character varying(100) ,
-    source_course_hours  numeric(9,2) ,
+    source_credit_hours  numeric(9,2) ,
     target_formatted_course  character varying(35) NOT NULL,
     target_course_code character varying(50),
     target_course_title  character varying(100),
-    target_course_hours  numeric(9,2)
+    target_credit_hours  numeric(9,2)
 );
 
 ALTER TABLE ONLY stg_external_course
@@ -840,11 +840,11 @@ CREATE TABLE external_substitutable_course (
     source_formatted_course character varying(35) NOT NULL,
     source_course_code  character varying(50) ,
     source_course_title character varying(100) ,
-    source_course_hours  numeric(9,2) ,
+    source_credit_hours  numeric(9,2) ,
     target_formatted_course  character varying(35) NOT NULL,
     target_course_code character varying(50),
     target_course_title  character varying(100),
-    target_course_hours  numeric(9,2)
+    target_credit_hours  numeric(9,2)
 );
 
 ALTER TABLE public.race OWNER TO sspadmin;

--- a/ssp-data-importer-impl/src/test/resources/sql/sqlserver/sqlserver-2.4.0-test-tables-create.sql
+++ b/ssp-data-importer-impl/src/test/resources/sql/sqlserver/sqlserver-2.4.0-test-tables-create.sql
@@ -813,11 +813,11 @@ CREATE TABLE stg_external_substitutable_course (
     [source_formatted_course] [nvarchar](35) NOT NULL,
     [source_course_code]  [nvarchar](50),
     [source_course_title][nvarchar](100),
-    [source_course_hours]  [decimal](9,2),
+    [source_credit_hours]  [decimal](9,2),
     [target_formatted_course]  [nvarchar](35) NOT NULL,
     [target_course_code] [nvarchar](50),
     [target_course_title]  [nvarchar](100),
-    [target_course_hours]  [decimal](9,2),
+    [target_credit_hours]  [decimal](9,2),
  PRIMARY KEY CLUSTERED 
 (
     [source_formatted_course] ASC,
@@ -1218,10 +1218,10 @@ CREATE TABLE external_substitutable_course (
     [source_formatted_course] [nvarchar](35) NOT NULL,
     [source_course_code]  [nvarchar](50),
     [source_course_title][nvarchar](100),
-    [source_course_hours]  [decimal](9,2),
+    [source_credit_hours]  [decimal](9,2),
     [target_formatted_course]  [nvarchar](35) NOT NULL,
     [target_course_code] [nvarchar](50),
     [target_course_title]  [nvarchar](100),
-    [target_course_hours]  [decimal](9,2),
+    [target_credit_hours]  [decimal](9,2),
 ) ON [PRIMARY]
 GO


### PR DESCRIPTION
https://issues.jasig.org/browse/SSP-2430

Updating external_substitutable_course tables' *course_hours columns to *credit_hours to match SSP table column names.
