### PR TITLE
﻿SSP-2436 Altering tests and code to be Windows friendly

### DIFF
--- a/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchFinalizerNoArchiveTest.java
+++ b/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchFinalizerNoArchiveTest.java
@@ -31,7 +31,6 @@ import org.junit.runner.RunWith;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -42,18 +41,16 @@ public class BatchFinalizerNoArchiveTest {
     @Autowired
     final private JobLauncherTestUtils jobLauncherTestUtils = new JobLauncherTestUtils();
 
-
-    final private String processDirectoryPath = "/tmp/batch-initialization/process/";
-    final private String upsertDirectoryPath = "/tmp/batch-initialization/upsert/";
-    final private String inputDirectoryPath = "/tmp/batch-initialization/input/";
-    final private String archiveDirectoryPath = "/tmp/batch-initialization/archive/";
+    private final String tempDir = System.getProperty("java.io.tmpdir");
+    final private String processDirectoryPath = tempDir + "/batch-initialization/process/";
+    final private String upsertDirectoryPath = tempDir + "/batch-initialization/upsert/";
+    final private String inputDirectoryPath = tempDir + "/batch-initialization/input/";
+    final private String archiveDirectoryPath = tempDir + "/batch-initialization/archive/";
 
     public BatchFinalizerNoArchiveTest() {
 
     }
 
-
-    @SuppressWarnings("unchecked")
     @Test
     public void testFinalizeNoArchive() throws Exception {
 
@@ -78,7 +75,7 @@ public class BatchFinalizerNoArchiveTest {
         Assert.assertTrue(directoryExists(inputDirectoryPath));
         Assert.assertTrue(!directoryExists(archiveDirectoryPath));
         Assert.assertTrue(directoryContainsFiles(processDirectoryPath, 0, csvFilter));
-        Assert.assertTrue(directoryContainsFiles(upsertDirectoryPath, 0, csvFilter));
+        Assert.assertTrue(directoryContainsFiles(upsertDirectoryPath, 0, csvFilter));       
         Assert.assertTrue(directoryContainsFiles(inputDirectoryPath, 0, csvFilter));
         Assert.assertEquals(BatchStatus.COMPLETED, exitStatus);
     }
@@ -138,17 +135,6 @@ public class BatchFinalizerNoArchiveTest {
             public boolean accept(File dir, String name) {
                 String lowercaseName = name.toLowerCase();
                 if (lowercaseName.endsWith(".csv")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-        };
-
-    private FilenameFilter zipFilter = new FilenameFilter() {
-            public boolean accept(File dir, String name) {
-                String lowercaseName = name.toLowerCase();
-                if (lowercaseName.endsWith(".zip")) {
                     return true;
                 } else {
                     return false;

--- a/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchFinalizerTest.java
+++ b/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchFinalizerTest.java
@@ -31,7 +31,6 @@ import org.junit.runner.RunWith;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.test.JobLauncherTestUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -43,17 +42,16 @@ public class BatchFinalizerTest {
     final private JobLauncherTestUtils jobLauncherTestUtils = new JobLauncherTestUtils();
 
 
-    final private String processDirectoryPath = "/tmp/batch-initialization/process/";
-    final private String upsertDirectoryPath = "/tmp/batch-initialization/upsert/";
-    final private String inputDirectoryPath = "/tmp/batch-initialization/input/";
-    final private String archiveDirectoryPath = "/tmp/batch-initialization/archive/";
+    private final String tempDir = System.getProperty("java.io.tmpdir");
+    final private String processDirectoryPath = tempDir + "/batch-initialization/process/";
+    final private String upsertDirectoryPath = tempDir + "/batch-initialization/upsert/";
+    final private String inputDirectoryPath = tempDir + "/batch-initialization/input/";
+    final private String archiveDirectoryPath = tempDir + "/batch-initialization/archive/";
 
     public BatchFinalizerTest() {
 
     }
 
-
-    @SuppressWarnings("unchecked")
     @Test
     public void testFinalizer() throws Exception {
 

--- a/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchInitializerCopyTest.java
+++ b/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchInitializerCopyTest.java
@@ -42,18 +42,15 @@ public class BatchInitializerCopyTest {
     final private JobLauncherTestUtils jobLauncherTestUtils = new JobLauncherTestUtils();
 
 
-    final private String processDirectoryPath = "/tmp/batch-initialization/process/";
-    final private String upsertDirectoryPath = "/tmp/batch-initialization/upsert/";
-    final private String inputDirectoryPath = "/tmp/batch-initialization/input/";
-
+    private final String tempDir = System.getProperty("java.io.tmpdir");
+    final private String processDirectoryPath = tempDir + "/batch-initialization/process/";
+    final private String upsertDirectoryPath = tempDir + "/batch-initialization/upsert/";
+    final private String inputDirectoryPath = tempDir + "/batch-initialization/input/";
 
     public BatchInitializerCopyTest() {
         super();
     }
 
-
-
-    @SuppressWarnings("unchecked")
     @Test
     public void testCopyToProcessDirectory() throws Exception {
 

--- a/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchInitializerHeaderFailTest.java
+++ b/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchInitializerHeaderFailTest.java
@@ -19,12 +19,9 @@
 package org.jasig.ssp.util.importer.job;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.Map.Entry;
 
 import junit.framework.Assert;
 
@@ -53,8 +50,9 @@ public class BatchInitializerHeaderFailTest {
     @Autowired
     private ApplicationContext applicationContext;
 
-    final private String processDirectoryPath = "/tmp/batch-initialization/process/";
-    final private String upsertDirectoryPath = "/tmp/batch-initialization/upsert/";
+    private final String tempDir = System.getProperty("java.io.tmpdir");
+    final private String processDirectoryPath = tempDir + "/batch-initialization/process/";
+    final private String upsertDirectoryPath = tempDir + "/batch-initialization/upsert/";
 
     public BatchInitializerHeaderFailTest() {
 
@@ -118,28 +116,6 @@ public class BatchInitializerHeaderFailTest {
             return true;
         return false;
     }
-
-    private Boolean directoryContainsFiles(String directoryPath, int count){
-        File file = new File(directoryPath);
-
-        if(!file.exists() || !file.isDirectory())
-            return false;
-
-        if(file.list(csvFilter).length == count)
-            return true;
-        return false;
-    }
-
-    private FilenameFilter csvFilter = new FilenameFilter() {
-            public boolean accept(File dir, String name) {
-                String lowercaseName = name.toLowerCase();
-                if (lowercaseName.endsWith(".csv")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-        };
 
     public String getProcessDirectoryPath() {
         return processDirectoryPath;

--- a/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchInitializerTest.java
+++ b/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchInitializerTest.java
@@ -45,9 +45,10 @@ public class BatchInitializerTest {
     @Autowired
     private ApplicationContext applicationContext;
 
-    final private String processDirectoryPath = "/tmp/batch-initialization/process/";
-    final private String upsertDirectoryPath = "/tmp/batch-initialization/upsert/";
-    final private String inputDirectoryPath = "/tmp/batch-initialization/input/";
+    private final String tempDir = System.getProperty("java.io.tmpdir");
+    final private String processDirectoryPath = tempDir + "/batch-initialization/process/";
+    final private String upsertDirectoryPath = tempDir + "/batch-initialization/upsert/";
+    final private String inputDirectoryPath = tempDir + "/batch-initialization/input/";
 
     public BatchInitializerTest() {
 

--- a/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchPartialUploadTest.java
+++ b/ssp-data-importer-impl/src/test/java/org/jasig/ssp/util/importer/job/BatchPartialUploadTest.java
@@ -48,7 +48,9 @@ public class BatchPartialUploadTest {
     final private JobLauncherTestUtils jobLauncherTestUtils = new JobLauncherTestUtils();
 
 
-    final private String inputDirectoryPath = "/tmp/batch-initialization/input/";
+    private final String tempDir = System.getProperty("java.io.tmpdir");
+    final private String inputDirectoryPath = tempDir + "/batch-initialization/input/";
+
 
     public BatchPartialUploadTest() {
 
@@ -61,6 +63,7 @@ public class BatchPartialUploadTest {
 
         deleteDirectory(inputDirectoryPath);
 
+     
         Assert.assertTrue(!directoryExists(inputDirectoryPath));
         JobExecution jobExecution =jobLauncherTestUtils.launchJob();
         BatchStatus exitStatus =  jobExecution.getStatus();
@@ -183,17 +186,6 @@ public class BatchPartialUploadTest {
             public boolean accept(File dir, String name) {
                 String lowercaseName = name.toLowerCase();
                 if (lowercaseName.endsWith(".csv")) {
-                    return true;
-                } else {
-                    return false;
-                }
-            }
-        };
-
-    private FilenameFilter zipFilter = new FilenameFilter() {
-            public boolean accept(File dir, String name) {
-                String lowercaseName = name.toLowerCase();
-                if (lowercaseName.endsWith(".zip")) {
                     return true;
                 } else {
                     return false;

--- a/ssp-data-importer-impl/src/test/resources/batch-initialization-header-fail/importdatajob-context-test.xml
+++ b/ssp-data-importer-impl/src/test/resources/batch-initialization-header-fail/importdatajob-context-test.xml
@@ -49,8 +49,8 @@
                                 p:metadataRepository-ref="metadataRepository"
                                 p:resources="batch-initialization-header-fail/*.csv"
                                 p:duplicateResources="false"
-                                p:processDirectory="file:/tmp/batch-initialization/process"
-                                p:upsertDirectory="file:/tmp/batch-initialization/upsert"/>
+                                p:processDirectory="file:${java.io.tmpdir}/batch-initialization/process"
+                                p:upsertDirectory="file:${java.io.tmpdir}/batch-initialization/upsert"/>
 
 
     <batch:job id="importJob" restartable="false">

--- a/ssp-data-importer-impl/src/test/resources/batch-initialization/importdatajob-context-test-copy.xml
+++ b/ssp-data-importer-impl/src/test/resources/batch-initialization/importdatajob-context-test-copy.xml
@@ -47,10 +47,10 @@
 
     <bean scope="step" id="batchInitializer" class="org.jasig.ssp.util.importer.job.tasklet.BatchInitializer"
                                 p:metadataRepository-ref="metadataRepository"
-                                p:resources="file:/tmp/batch-initialization/input/*"
+                                p:resources="file:${java.io.tmpdir}/batch-initialization/input/*"
                                 p:duplicateResources="true"
-                                p:processDirectory="file:/tmp/batch-initialization/process"
-                                p:upsertDirectory="file:/tmp/batch-initialization/upsert"/>
+                                p:processDirectory="file:${java.io.tmpdir}/batch-initialization/process"
+                                p:upsertDirectory="file:${java.io.tmpdir}/batch-initialization/upsert"/>
 
 
     <batch:job id="importJob" restartable="false">

--- a/ssp-data-importer-impl/src/test/resources/batch-initialization/importdatajob-context-test-finalizer-no-archive.xml
+++ b/ssp-data-importer-impl/src/test/resources/batch-initialization/importdatajob-context-test-finalizer-no-archive.xml
@@ -30,15 +30,15 @@
             http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean scope="step" id="partialUploadGuard" class="org.jasig.ssp.util.importer.job.tasklet.PartialUploadGuard"
-                                p:resources="file:/tmp/batch-initialization/input/*"
+                                p:resources="file:${java.io.tmpdir}/batch-initialization/input/*"
                                 p:lagTimeBeforeStartInMinutes="0"/>
 
 
    <bean id="batchFinaliser" class="org.jasig.ssp.util.importer.job.tasklet.BatchFinalizer"
-            p:archiveDirectory="file:/tmp/batch-initialization/archive"
-            p:inputDirectory="file:/tmp/batch-initialization/input"
-            p:upsertDirectory="file:/tmp/batch-initialization/upsert"
-            p:processDirectory="file:/tmp/batch-initialization/process"
+            p:archiveDirectory="file:${java.io.tmpdir}/batch-initialization/archive"
+            p:inputDirectory="file:${java.io.tmpdir}/batch-initialization/input"
+            p:upsertDirectory="file:${java.io.tmpdir}/batch-initialization/upsert"
+            p:processDirectory="file:${java.io.tmpdir}/batch-initialization/process"
             p:batchTitle="Test Batch"
             p:archiveFiles="NONE"
             p:retainInputFiles="false"/>

--- a/ssp-data-importer-impl/src/test/resources/batch-initialization/importdatajob-context-test-finalizer.xml
+++ b/ssp-data-importer-impl/src/test/resources/batch-initialization/importdatajob-context-test-finalizer.xml
@@ -30,15 +30,15 @@
             http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <bean scope="step" id="partialUploadGuard" class="org.jasig.ssp.util.importer.job.tasklet.PartialUploadGuard"
-                                p:resources="file:/tmp/batch-initialization/input/*"
+                                p:resources="file:${java.io.tmpdir}/batch-initialization/input/*"
                                 p:lagTimeBeforeStartInMinutes="0"/>
 
 
    <bean id="batchFinaliser" class="org.jasig.ssp.util.importer.job.tasklet.BatchFinalizer"
-            p:archiveDirectory="file:/tmp/batch-initialization/archive"
-            p:inputDirectory="file:/tmp/batch-initialization/input"
-            p:upsertDirectory="file:/tmp/batch-initialization/upsert"
-            p:processDirectory="file:/tmp/batch-initialization/process"
+            p:archiveDirectory="file:${java.io.tmpdir}/batch-initialization/archive"
+            p:inputDirectory="file:${java.io.tmpdir}/batch-initialization/input"
+            p:upsertDirectory="file:${java.io.tmpdir}/batch-initialization/upsert"
+            p:processDirectory="file:${java.io.tmpdir}/batch-initialization/process"
             p:batchTitle="Test Batch"
             p:archiveFiles="ALL"
             p:retainInputFiles="false"/>

--- a/ssp-data-importer-impl/src/test/resources/batch-initialization/importdatajob-context-test-partial-upload.xml
+++ b/ssp-data-importer-impl/src/test/resources/batch-initialization/importdatajob-context-test-partial-upload.xml
@@ -50,18 +50,18 @@
     </bean>
 
     <bean scope="step" id="partialUploadGuard" class="org.jasig.ssp.util.importer.job.tasklet.PartialUploadGuard"
-                                p:resources="file:/tmp/batch-initialization/input/*"
-                                p:directory="file:/tmp/batch-initialization/input"
+                                p:resources="file:${java.io.tmpdir}/batch-initialization/input/*"
+                                p:directory="file:${java.io.tmpdir}/batch-initialization/input"
                                 p:lagTimeBeforeStartInMinutes="2">
                                 <property name="jobOperator" ref="jobOperator"/>
                                 </bean>
 
 
    <bean id="batchFinaliser" class="org.jasig.ssp.util.importer.job.tasklet.BatchFinalizer"
-            p:archiveDirectory="file:/tmp/batch-initialization/archive"
-            p:inputDirectory="file:/tmp/batch-initialization/input"
-            p:upsertDirectory="file:/tmp/batch-initialization/upsert"
-            p:processDirectory="file:/tmp/batch-initialization/process"
+            p:archiveDirectory="file:${java.io.tmpdir}/batch-initialization/archive"
+            p:inputDirectory="file:${java.io.tmpdir}/batch-initialization/input"
+            p:upsertDirectory="file:${java.io.tmpdir}/batch-initialization/upsert"
+            p:processDirectory="file:${java.io.tmpdir}/batch-initialization/process"
             p:batchTitle="Test Batch"
             p:archiveFiles="ALL"
             p:retainInputFiles="false"/>

--- a/ssp-data-importer-impl/src/test/resources/batch-initialization/importdatajob-context-test.xml
+++ b/ssp-data-importer-impl/src/test/resources/batch-initialization/importdatajob-context-test.xml
@@ -47,10 +47,10 @@
 
     <bean scope="step" id="batchInitializer" class="org.jasig.ssp.util.importer.job.tasklet.BatchInitializer"
                                 p:metadataRepository-ref="metadataRepository"
-                                p:resources="file:/tmp/batch-initialization/input/*"
+                                p:resources="file:${java.io.tmpdir}/batch-initialization/input/*"
                                 p:duplicateResources="${batch.duplicate:false}"
-                                p:processDirectory="file:/tmp/batch-initialization/process"
-                                p:upsertDirectory="file:/tmp/batch-initialization/upsert"/>
+                                p:processDirectory="file:${java.io.tmpdir}/batch-initialization/process"
+                                p:upsertDirectory="file:${java.io.tmpdir}/batch-initialization/upsert"/>
 
 
     <batch:job id="importJob" restartable="false">

--- a/ssp-data-importer-impl/src/test/resources/batch-initializer-properties/ssp-importer.properties
+++ b/ssp-data-importer-impl/src/test/resources/batch-initializer-properties/ssp-importer.properties
@@ -19,9 +19,9 @@
 
 #FOLDER LOCATIONS
 batch.tables.input.folder=classpath:/data-test/ssp-external-tables-input-test/
-batch.tables.process.folder=file:/tmp/data-test/tmp/ssp-external-tables-process/
-batch.tables.upsert.folder=file:/tmp/data-test/tmp/ssp-external-tables-upsert/
-batch.tables.archive.folder=file:/tmp/data-test/tmp/ssp-external-tables-archive/
+batch.tables.process.folder=file:${java.io.tmpdir}/data-test/tmp/ssp-external-tables-process/
+batch.tables.upsert.folder=file:${java.io.tmpdir}/data-test/tmp/ssp-external-tables-upsert/
+batch.tables.archive.folder=file:${java.io.tmpdir}/data-test/tmp/ssp-external-tables-archive/
 
 #FILE TYPE
 batch.files.accepted=*.csv

--- a/ssp-data-importer-impl/src/test/resources/ssp-importer.test.properties
+++ b/ssp-data-importer-impl/src/test/resources/ssp-importer.test.properties
@@ -21,3 +21,8 @@ batch.table.input.duplicate=true
 ### DO NOT SET URL TO DATABASE CONTAINING DATA YOU ARE INTERESTED IN!
 ### TESTS WRITE TO DATABASE AND TRUNCATE TABLES TO CLEAR!
 batch.jdbc.url=jdbc:postgresql://127.0.0.1:5432/ssp-test-importer-db
+
+batch.tables.input.folder=classpath:/data-test/ssp-external-tables-input-test/
+batch.tables.process.folder=file:${java.io.tmpdir}/data-test/tmp/ssp-external-tables-process/
+batch.tables.upsert.folder=file:${java.io.tmpdir}/data-test/tmp/ssp-external-tables-upsert/
+batch.tables.archive.folder=file:${java.io.tmpdir}/data-test/tmp/ssp-external-tables-archive/

--- a/ssp-data-importer-impl/src/test/resources/twodottwo-test-input-stage-fail/importdatajob-context-test.xml
+++ b/ssp-data-importer-impl/src/test/resources/twodottwo-test-input-stage-fail/importdatajob-context-test.xml
@@ -73,7 +73,7 @@
     <!-- FINAL PROCESSING OF UPSERT FOLDER INSERT CONTENTS OF UPSERT FOLDER -> DATABASE  -->
 
     <bean  scope="step" id="singleFilteredCsvItemReader" class="org.jasig.ssp.util.importer.job.csv.RawItemCsvReader" >
-        <property name="resources" value="#{stepExecutionContext[fileName]}"/>
+        <property name="resource" value="#{stepExecutionContext[fileName]}"/>
     </bean>
 
     <bean  scope="step" id="compositeTableWriter"


### PR DESCRIPTION
- Leverage java.io.tmpdir system property instead of using /tmp
- Fix the windows delete file issue
- Fixed a couple of typos
